### PR TITLE
fix: missing file extension on import/export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,4 +6,4 @@ export {
   mdastDefListTerm2hast,
   mdastDefListDescription2hast,
 } from './lib/to-hast.js';
-export * from './lib/types';
+export * from './lib/types.js';


### PR DESCRIPTION
NodeJS requires file extensions on relative imports.